### PR TITLE
Исправление ошибок

### DIFF
--- a/FormalLanguages/Character.fs
+++ b/FormalLanguages/Character.fs
@@ -16,9 +16,11 @@ module Character =
 
     /// Возвращает строковое представление последовательности символов.
     let toString characters =
-        characters
-        |> Seq.map (function
-                        | Terminal x    -> x.ToString ()
-                        | Nonterminal x -> x.ToString ()
-                        | Empty         -> "ε" )
-        |> Seq.reduce (+)
+        match Seq.length characters with
+        | 0 -> ""
+        | _ -> characters
+            |> Seq.map (function
+                            | Terminal x    -> x.ToString ()
+                            | Nonterminal x -> x.ToString ()
+                            | Empty         -> "ε" )
+            |> Seq.reduce (+)


### PR DESCRIPTION
Исправлены следующие ошибки:
- Пустые последовательности нельзя было привести к строке.
- Некорректный разбор параметров командной строки.
- Завершение программы из-за ошибки, если входную последовательность нельзя было разобрать с помощью данной грамматики.